### PR TITLE
Add support for a custom JSON formatter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ serde_json = "1.0.81"
 thiserror = "1.0.30"
 
 ethereum_consensus = { git = "https://github.com/ralexstokes/ethereum_consensus" }
+axum = "0.5.4"
+mime = "0.3.16"

--- a/src/beacon_json/error.rs
+++ b/src/beacon_json/error.rs
@@ -1,0 +1,149 @@
+use axum::{
+    async_trait,
+    body::{Bytes, HttpBody},
+    extract::{FromRequest, RequestParts},
+    http::{self, header, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    BoxError, Error,
+};
+
+#[derive(Debug)]
+pub struct JsonDataError(pub Error);
+
+impl axum::response::IntoResponse for JsonDataError {
+    fn into_response(self) -> axum::response::Response {
+        (
+            http::StatusCode::UNPROCESSABLE_ENTITY,
+            format!(
+                concat!(
+                    "Failed to deserialize the JSON body into the target type",
+                    ": {}"
+                ),
+                self.0
+            ),
+        )
+            .into_response()
+    }
+}
+
+impl std::fmt::Display for JsonDataError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Failed to deserialize the JSON body into the target type"
+        )
+    }
+}
+
+impl std::error::Error for JsonDataError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+#[derive(Debug)]
+pub struct JsonSyntaxError(pub Error);
+
+impl axum::response::IntoResponse for JsonSyntaxError {
+    fn into_response(self) -> axum::response::Response {
+        (
+            http::StatusCode::BAD_REQUEST,
+            format!(
+                concat!("Failed to parse the request body as JSON", ": {}"),
+                self.0
+            ),
+        )
+            .into_response()
+    }
+}
+
+impl std::fmt::Display for JsonSyntaxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Failed to parse the request body as JSON")
+    }
+}
+
+impl std::error::Error for JsonSyntaxError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct MissingJsonContentType;
+
+impl axum::response::IntoResponse for MissingJsonContentType {
+    fn into_response(self) -> axum::response::Response {
+        (
+            http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "Expected request with `Content-Type: application/json`",
+        )
+            .into_response()
+    }
+}
+
+impl std::fmt::Display for MissingJsonContentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Expected request with `Content-Type: application/json`")
+    }
+}
+
+impl std::error::Error for MissingJsonContentType {}
+
+#[derive(Debug)]
+pub enum JsonRejection {
+    JsonDataError(JsonDataError),
+    JsonSyntaxError(JsonSyntaxError),
+    MissingJsonContentType(MissingJsonContentType),
+    // TODO fill out
+    BytesRejection,
+}
+
+impl axum::response::IntoResponse for JsonRejection {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            Self::JsonDataError(inner) => inner.into_response(),
+            Self::JsonSyntaxError(inner) => inner.into_response(),
+            Self::MissingJsonContentType(inner) => inner.into_response(),
+            Self::BytesRejection => "failure".into_response(),
+        }
+    }
+}
+
+impl From<JsonDataError> for JsonRejection {
+    fn from(inner: JsonDataError) -> Self {
+        Self::JsonDataError(inner)
+    }
+}
+impl From<JsonSyntaxError> for JsonRejection {
+    fn from(inner: JsonSyntaxError) -> Self {
+        Self::JsonSyntaxError(inner)
+    }
+}
+impl From<MissingJsonContentType> for JsonRejection {
+    fn from(inner: MissingJsonContentType) -> Self {
+        Self::MissingJsonContentType(inner)
+    }
+}
+
+impl std::fmt::Display for JsonRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::JsonDataError(inner) => write!(f, "{}", inner),
+            Self::JsonSyntaxError(inner) => write!(f, "{}", inner),
+            Self::MissingJsonContentType(inner) => write!(f, "{}", inner),
+            Self::BytesRejection => write!(f, "failure"),
+        }
+    }
+}
+
+impl std::error::Error for JsonRejection {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::JsonDataError(inner) => Some(inner),
+            Self::JsonSyntaxError(inner) => Some(inner),
+            Self::MissingJsonContentType(inner) => Some(inner),
+            Self::BytesRejection => None,
+        }
+    }
+}

--- a/src/beacon_json/json.rs
+++ b/src/beacon_json/json.rs
@@ -1,0 +1,132 @@
+use crate::beacon_json::error::*;
+use axum::{
+    async_trait,
+    body::{Bytes, HttpBody},
+    extract::{FromRequest, RequestParts},
+    http::{self, header, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    BoxError, Error,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use std::ops::{Deref, DerefMut};
+
+pub struct Json<T>(pub T);
+
+#[async_trait]
+impl<B, T> FromRequest<B> for Json<T>
+where
+    T: DeserializeOwned,
+    B: axum::body::HttpBody + Send,
+    B::Data: Send,
+    B::Error: Into<BoxError>,
+{
+    type Rejection = JsonRejection;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
+        // NOTE: implementation is forked from `axum::Json` for now...
+        if json_content_type(req) {
+            let bytes = Bytes::from_request(req)
+                .await
+                .map_err(|_| JsonRejection::BytesRejection)?;
+
+            let value = match /*crate::beacon_json::serde::from_slice(&bytes) {*/
+            serde_json::from_slice(&bytes) {
+                Ok(value) => value,
+                Err(err) => {
+                    let rejection = match err.classify() {
+                        serde_json::error::Category::Data => JsonDataError(Error::new(err)).into(),
+                        serde_json::error::Category::Syntax | serde_json::error::Category::Eof => {
+                            JsonSyntaxError(Error::new(err)).into()
+                        }
+                        serde_json::error::Category::Io => {
+                            if cfg!(debug_assertions) {
+                                // we don't use `serde_json::from_reader` and instead always buffer
+                                // bodies first, so we shouldn't encounter any IO errors
+                                unreachable!()
+                            } else {
+                                JsonSyntaxError(Error::new(err)).into()
+                            }
+                        }
+                    };
+                    return Err(rejection);
+                }
+            };
+
+            Ok(Json(value))
+        } else {
+            Err(MissingJsonContentType.into())
+        }
+    }
+}
+
+fn json_content_type<B>(req: &RequestParts<B>) -> bool {
+    let content_type = if let Some(content_type) = req.headers().get(header::CONTENT_TYPE) {
+        content_type
+    } else {
+        return false;
+    };
+
+    let content_type = if let Ok(content_type) = content_type.to_str() {
+        content_type
+    } else {
+        return false;
+    };
+
+    let mime = if let Ok(mime) = content_type.parse::<mime::Mime>() {
+        mime
+    } else {
+        return false;
+    };
+
+    let is_json_content_type = mime.type_() == "application"
+        && (mime.subtype() == "json" || mime.suffix().map_or(false, |name| name == "json"));
+
+    is_json_content_type
+}
+
+impl<T> Deref for Json<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Json<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> From<T> for Json<T> {
+    fn from(inner: T) -> Self {
+        Self(inner)
+    }
+}
+
+impl<T> IntoResponse for Json<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> Response {
+        match crate::beacon_json::serde::to_vec(&self.0) {
+            Ok(bytes) => (
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static(mime::APPLICATION_JSON.as_ref()),
+                )],
+                bytes,
+            )
+                .into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+                )],
+                err.to_string(),
+            )
+                .into_response(),
+        }
+    }
+}

--- a/src/beacon_json/mod.rs
+++ b/src/beacon_json/mod.rs
@@ -1,0 +1,5 @@
+mod error;
+mod json;
+mod serde;
+
+pub use json::Json;

--- a/src/beacon_json/serde.rs
+++ b/src/beacon_json/serde.rs
@@ -1,0 +1,43 @@
+use serde::Serialize;
+use serde_json::{ser::Formatter, Error, Serializer};
+use std::io::{self, Write};
+// use serde::de;
+
+// pub(crate) fn from_slice<'a, T>(v: &'a [u8]) -> Result<T, Error>
+// where
+//     T: de::Deserialize<'a>,
+// {
+//     // let mut de = serde::Deserializer::from_slice(v);
+//     // let value = T::deserialize(Wrapper(&mut de))?;
+//     // de.end().unwrap();
+//     // Ok(value)
+// }
+
+struct BeaconFormatter;
+
+impl Formatter for BeaconFormatter {
+    fn write_u8<W>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
+    where
+        W: ?Sized + Write,
+    {
+        write!(writer, "\"{}\"", value)
+    }
+
+    fn write_u64<W>(&mut self, writer: &mut W, value: u64) -> io::Result<()>
+    where
+        W: ?Sized + Write,
+    {
+        write!(writer, "\"{}\"", value)
+    }
+}
+
+pub(crate) fn to_vec<T>(value: &T) -> Result<Vec<u8>, Error>
+where
+    T: ?Sized + Serialize,
+{
+    let mut writer = Vec::with_capacity(128);
+    let formatter = BeaconFormatter;
+    let mut ser = Serializer::with_formatter(&mut writer, formatter);
+    value.serialize(&mut ser)?;
+    Ok(writer)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod api_client;
+pub mod beacon_json;
 mod serde;
 
 pub use api_client::*;


### PR DESCRIPTION
The beacon APIs spec uses a custom notation for some data, e.g. writing all numeric types as base 10 strings.

Because of this, special support is required to instruct `serde` how to handle the exceptional data.

The approach currently taken in this repo (and dependency repos) is to overwrite each exceptional case with the appropriate serialization and deserialization routines.

This PR is a WIP, experimental approach to solve this problem at the other end of the `serde` pipeline by instead modifying `serde_json`. There is support for a custom serialization formatter but we will need to implement a custom Deserializer manually.

There is another issue beyond needing to handle the manual serde which is extending any HTTP library to use the `serde_json` customizations. This PR starts to make the required changes for an `axum` middleware and a cursory glance at `reqwest` suggests much more invasive changes would be required... (this suggests the current solution, while error prone -- can't miss any fields that need converting -- is preferable)