### PR TITLE
implement get_node_version()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ http = "0.2.7"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.81"
+itertools = "0.10.3"
 
 thiserror = "1.0.30"
 

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -8,7 +8,7 @@ use crate::types::{
     FinalityCheckpoints, GenesisDetails, HealthStatus, NetworkIdentity, PeerDescription,
     PeerDescriptor, PeerSummary, ProposerDuty, PubkeyOrIndex, RootData, StateId,
     SyncCommitteeDescriptor, SyncCommitteeDuty, SyncCommitteeSummary, SyncStatus, ValidatorStatus,
-    ValidatorSummary, Value,
+    ValidatorSummary, Value, VersionData,
 };
 use ethereum_consensus::altair::mainnet::{
     SignedContributionAndProof, SyncCommitteeContribution, SyncCommitteeMessage,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,24 @@
+use beacon_api_client::Client;
+use beacon_api_client::StateId;
+use url::Url;
+
+#[tokio::main]
+async fn main() {
+    let s = "http://127.0.0.1:8003/";
+    let url: Url = Url::parse(s).unwrap();
+    let client = Client::new(url);
+
+    let root = client.get_state_root(StateId::Finalized).await;
+    let fork = client.get_fork(StateId::Finalized).await;
+
+    // unwrap fork and extract fields
+    let fk = fork.unwrap();
+    let pv = fk.previous_version;
+    let cv = fk.current_version;
+    let ep = fk.epoch;
+
+    println!("\nroot:\n{:?}\n", root.unwrap());
+    println!("fork.previous_version = {:?}", pv);
+    println!("fork.current_version = {:?}", cv);
+    println!("fork.epoch = {:?}", ep);
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,11 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Serialize, Deserialize)]
+pub struct VersionData {
+    pub version: String,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct GenesisDetails {
     #[serde(with = "crate::serde::as_string")]
     pub genesis_time: u64,


### PR DESCRIPTION
- implements `get_node_version()` in `api_client.rs`
- adds `main.rs` as entry point and requests node version from local Lighthouse node
- adds `VersionData` type to `types`
