### PR TITLE
Implement `get_validator` method

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -134,10 +134,13 @@ impl Client {
     }
 
     pub async fn get_validator(
-        id: StateId,
+        &self,
+        state_id: StateId,
         validator_id: PubkeyOrIndex,
     ) -> Result<ValidatorSummary, Error> {
-        unimplemented!("")
+        let path = format!("eth/v1/beacon/states/{state_id}/validators/{validator_id}");
+        let result: Value<ValidatorSummary> = self.get(&path).await?;
+        Ok(result.data)
     }
 
     pub async fn get_balances(

--- a/src/types.rs
+++ b/src/types.rs
@@ -69,6 +69,7 @@ pub struct FinalityCheckpoints {
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ValidatorStatus {
     PendingInitialized,
     PendingQueued,
@@ -89,6 +90,16 @@ pub enum ValidatorStatus {
 pub enum PubkeyOrIndex {
     Pubkey(BlsPublicKey),
     Index(ValidatorIndex),
+}
+
+impl fmt::Display for PubkeyOrIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let printable = match *self {
+            PubkeyOrIndex::Pubkey(ref pk) => pk.to_string(),
+            PubkeyOrIndex::Index(i) => i.to_string(),
+        };
+        write!(f, "{}", printable)
+    }
 }
 
 pub struct ValidatorDescriptor {


### PR DESCRIPTION
Implements the beacon api method https://ethereum.github.io/beacon-APIs/#/Beacon/getStateValidator