### PR TITLE
implement get_beacon_header_at_head()

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -233,7 +233,7 @@ impl Client {
     }
 
     pub async fn get_beacon_header_at_head(&self) -> Result<BeaconHeaderSummaryOuter, Error> {
-        let result: BeaconHeaderSummaryOuter = self.get(&"eth/v1/beacon/headers/head").await?;
+        let result: BeaconHeaderSummaryOuter = self.get("eth/v1/beacon/headers/head").await?;
         Ok(result)
     }
 

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -3,11 +3,11 @@
 
 use crate::error::ApiError;
 use crate::types::{
-    ApiResult, AttestationDuty, BalanceSummary, BeaconHeaderSummary, BeaconProposerRegistration,
-    BlockId, CommitteeDescriptor, CommitteeFilter, CommitteeSummary, EventTopic,
-    FinalityCheckpoints, GenesisDetails, HealthStatus, PeerSummary, ProposerDuty, PublicKeyOrIndex,
-    RootData, StateId, SyncCommitteeDescriptor, SyncCommitteeDuty, SyncCommitteeSummary,
-    SyncStatus, ValidatorStatus, ValidatorSummary, Value, VersionData,
+    ApiResult, AttestationDuty, BalanceSummary, BeaconHeaderSummary, BeaconHeaderSummaryOuter,
+    BeaconProposerRegistration, BlockId, CommitteeDescriptor, CommitteeFilter, CommitteeSummary,
+    EventTopic, FinalityCheckpoints, GenesisDetails, HealthStatus, PeerSummary, ProposerDuty,
+    PublicKeyOrIndex, RootData, StateId, SyncCommitteeDescriptor, SyncCommitteeDuty,
+    SyncCommitteeSummary, SyncStatus, ValidatorStatus, ValidatorSummary, Value, VersionData,
 };
 #[cfg(feature = "peer-id")]
 use crate::types::{NetworkIdentity, PeerDescription, PeerDescriptor};
@@ -232,11 +232,15 @@ impl Client {
         unimplemented!("")
     }
 
-    pub async fn get_beacon_header_at_head(&self) -> Result<BeaconHeaderSummary, Error> {
-        unimplemented!("")
+    pub async fn get_beacon_header_at_head(&self) -> Result<BeaconHeaderSummaryOuter, Error> {
+        let result: BeaconHeaderSummaryOuter = self.get(&"eth/v1/beacon/headers/head").await?;
+        Ok(result)
     }
 
-    pub async fn get_beacon_header_for_slot(slot: Slot) -> Result<BeaconHeaderSummary, Error> {
+    pub async fn get_beacon_header_for_slot(
+        &self,
+        slot: Slot,
+    ) -> Result<BeaconHeaderSummary, Error> {
         unimplemented!("")
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -199,6 +199,12 @@ pub struct SyncCommitteeSummary {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct BeaconHeaderSummaryOuter {
+    pub execution_optimistic: bool,
+    pub header_summary: BeaconHeaderSummary,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct BeaconHeaderSummary {
     pub root: Root,
     pub canonical: bool,


### PR DESCRIPTION
attempting to implement `get_header_at_head()`.

This code panics in `http_get()` with an error that indicates a malformed type descriptor for the return value: 

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Http(reqwest::Error { kind: Decode, source: Error("data did not match any variant of untagged enum ApiResult", line: 0, column: 0) })', src/main.rs:11:59
```

I'm struggling to work out why.

I am requesting the data from a local Lighthouse node that is post-altair. Curl requests to the endpoint successfully return the following data structure:

```
{"execution_optimistic":false,
"data":{
	"root":"0xb9fdfdbf10d36afc20283f12a423e11be6172752540750c2d6422d5a52c08b7f",
	"canonical":true,
	"header":{
		"message":
			{"slot":"0", 				
			"proposer_index":"0",
			"parent_root":"0x0000000000000000000000000000000000000000000000000000000000000000",
			"state_root":"0xe43e5d3518ade29e7a21525ee8986a6754b63e8af195b1e4dc6ecb89aca30cf0",
			"body_root":"0x5bbaf31d784ad05f513489748eefa4119bbde2c8ffbc1772911e332d136c50ea"},
	"signature":"0x0000000000000000000000000000000000000000000000000000000000000000000"}}
```

AFAICT I have replicated this structure in the new type `BeaconHeaderSummaryOuter`. 

@ralexstokes any pointers would be greatly appreciated!

