### PR TITLE
implement endpoints in config namespace

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -4,7 +4,7 @@
 use crate::error::ApiError;
 use crate::types::{
     ApiResult, AttestationDuty, BalanceSummary, BeaconHeaderSummary, BeaconProposerRegistration,
-    BlockId, CommitteeDescriptor, CommitteeFilter, CommitteeSummary, EventTopic,
+    BlockId, CommitteeDescriptor, CommitteeFilter, CommitteeSummary, DepositContract, EventTopic,
     FinalityCheckpoints, GenesisDetails, HealthStatus, PeerSummary, ProposerDuty, PublicKeyOrIndex,
     RootData, StateId, SyncCommitteeDescriptor, SyncCommitteeDuty, SyncCommitteeSummary,
     SyncStatus, ValidatorStatus, ValidatorSummary, Value, VersionData,
@@ -23,8 +23,7 @@ use ethereum_consensus::phase0::mainnet::{
     ProposerSlashing, SignedAggregateAndProof, SignedBeaconBlock, SignedVoluntaryExit,
 };
 use ethereum_consensus::primitives::{
-    Bytes32, ChainId, CommitteeIndex, Coordinate, Epoch, ExecutionAddress, RandaoReveal, Root,
-    Slot, ValidatorIndex,
+    Bytes32, CommitteeIndex, Coordinate, Epoch, RandaoReveal, Root, Slot, ValidatorIndex,
 };
 use http::StatusCode;
 use itertools::Itertools;
@@ -294,7 +293,7 @@ impl Client {
             request = request.query(&[("slot", slot)]);
         }
         if let Some(committee_index) = committee_index {
-            request = request.query(&[("committe_index", committee_index)]);
+            request = request.query(&[("committee_index", committee_index)]);
         }
         let response = request.send().await?;
         let result: ApiResult<Value<Vec<Attestation>>> = response.json().await?;
@@ -339,16 +338,19 @@ impl Client {
     }
 
     /* config namespace */
-    pub async fn get_fork_schedule() -> Result<Vec<Fork>, Error> {
-        unimplemented!("")
+    pub async fn get_fork_schedule(&self) -> Result<Vec<Fork>, Error> {
+        let result: Value<Vec<Fork>> = self.get("eth/v1/config/fork_schedule/").await?;
+        Ok(result.data)
     }
 
-    pub async fn get_spec() -> Result<HashMap<String, String>, Error> {
-        unimplemented!("")
+    pub async fn get_spec(&self) -> Result<HashMap<String, String>, Error> {
+        let result: Value<HashMap<String, String>> = self.get("eth/v1/config/spec/").await?;
+        Ok(result.data)
     }
 
-    pub async fn get_deposit_contract_address() -> Result<(ChainId, ExecutionAddress), Error> {
-        unimplemented!("")
+    pub async fn get_deposit_contract_address(&self) -> Result<DepositContract, Error> {
+        let result: Value<DepositContract> = self.get("/eth/v1/config/deposit_contract").await?;
+        Ok(result.data)
     }
 
     /* debug namespace */

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -339,12 +339,12 @@ impl Client {
 
     /* config namespace */
     pub async fn get_fork_schedule(&self) -> Result<Vec<Fork>, Error> {
-        let result: Value<Vec<Fork>> = self.get("eth/v1/config/fork_schedule/").await?;
+        let result: Value<Vec<Fork>> = self.get("eth/v1/config/fork_schedule").await?;
         Ok(result.data)
     }
 
     pub async fn get_spec(&self) -> Result<HashMap<String, String>, Error> {
-        let result: Value<HashMap<String, String>> = self.get("eth/v1/config/spec/").await?;
+        let result: Value<HashMap<String, String>> = self.get("eth/v1/config/spec").await?;
         Ok(result.data)
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,8 +3,8 @@ use crate::error::ApiError;
 use ethereum_consensus::networking::{Enr, MetaData, Multiaddr, PeerId};
 use ethereum_consensus::phase0::mainnet::{Checkpoint, SignedBeaconBlockHeader, Validator};
 use ethereum_consensus::primitives::{
-    BlsPublicKey, CommitteeIndex, Epoch, ExecutionAddress, Gwei, Root, Slot, ValidatorIndex,
-    Version,
+    BlsPublicKey, ChainId, CommitteeIndex, Epoch, ExecutionAddress, Gwei, Root, Slot,
+    ValidatorIndex, Version,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::HashMap;
@@ -13,6 +13,13 @@ use std::fmt;
 #[derive(Serialize, Deserialize)]
 pub struct VersionData {
     pub version: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DepositContract {
+    #[serde(with = "crate::serde::as_string")]
+    pub chain_id: ChainId,
+    pub address: ExecutionAddress,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
Implements all three endpoints in the`config` namespace.
Also corrects a typo `committe_index` --> `committee_index`.

#8 