### PR TITLE
Update ethereum-consensus dependecy, re-export dependecies used in public API

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install
       run: rustup update stable
+    - name: Install protobuf compiler for the libp2p-core dependency
+      uses: arduino/setup-protoc@v1
     - name: Rust Cache
       uses: Swatinem/rust-cache@v1.3.0
     - name: Format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "0.10.3"
 
 thiserror = "1.0.30"
 
-ethereum-consensus = { git = "https://github.com/sigp/ethereum-consensus", rev = "e1188b1" }
+ethereum-consensus = { git = "https://github.com/sigp/ethereum-consensus", rev = "0d484789ec175717701bf0ea994e1b84407fee78" }
 
 [features]
 peer-id = ["ethereum-consensus/peer-id"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "0.10.3"
 
 thiserror = "1.0.30"
 
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "e1188b1" }
+ethereum-consensus = { git = "https://github.com/sigp/ethereum-consensus", rev = "e1188b1" }
 
 [features]
 peer-id = ["ethereum-consensus/peer-id"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,8 @@ mod types;
 
 pub use api_client::*;
 pub use error::ApiError;
+pub use ethereum_consensus;
+pub use http;
+pub use reqwest;
 pub use types::*;
+pub use url;


### PR DESCRIPTION
Pending on
- [ ] https://github.com/ralexstokes/ethereum-consensus/pull/159

The `ethereum-consensus` dependecy needs to be declared when using `beacon-api-client` for anyone who wants to use a type not already re-exported or functions related to the exported-types. Re-exporting the full dependency makes it unnecessary to declare a (potentially incompatible) `ethereum-consensus` dependecy by simply using this one. 

This should make it easier to use `beacon-api-client`