### PR TITLE
Integration tests

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -29,7 +29,7 @@ pub struct DepositContract {
     pub address: ExecutionAddress,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct GenesisDetails {
     #[serde(with = "crate::serde::as_string")]
     pub genesis_time: u64,
@@ -95,7 +95,7 @@ enum ExecutionStatus {
     Optimistic,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct FinalityCheckpoints {
     pub previous_justified: Checkpoint,
     pub current_justified: Checkpoint,
@@ -179,7 +179,7 @@ pub struct ValidatorSummary {
     pub validator: Validator,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct BalanceSummary {
     #[serde(with = "crate::serde::as_string")]
     pub index: ValidatorIndex,
@@ -194,7 +194,7 @@ pub struct CommitteeFilter {
     pub slot: Option<Slot>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct CommitteeSummary {
     #[serde(with = "crate::serde::as_string")]
     pub index: CommitteeIndex,
@@ -218,7 +218,7 @@ pub struct BeaconHeaderSummary {
     pub canonical: bool,
     pub signed_header: SignedBeaconBlockHeader,
 }
-
+#[derive(Serialize, Deserialize)]
 pub enum EventTopic {
     Head,
     Block,

--- a/tests/common/constants.rs
+++ b/tests/common/constants.rs
@@ -1,0 +1,25 @@
+pub const GENESIS_TIME: u64 = 1606824023;
+pub const GENESIS_STATE_ROOT: [u8; 32] = [
+    126, 118, 136, 14, 182, 123, 189, 200, 98, 80, 170, 87, 137, 88, 233, 208, 103, 94, 100, 231,
+    20, 51, 120, 85, 32, 79, 181, 171, 170, 248, 44, 43,
+];
+pub const GENESIS_FORK_VERSION: u32 = 0x00000000;
+pub const VALIDATOR_0 :&str  =
+"0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c95";
+
+// pub const genesis_block_root = 0xeade62f0457b2fdf48e7d3fc4b60736688286be7c7a3ac4c9a16a5e0600bd9e4
+// genesis_validators_root = 0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95
+// genesis_validators_count = 21063
+// genesis_active_validators_count = 21063
+// genesis_total_active_stake_gwei = 674016000000000
+// genesis_total_balance_gwei = 674144000000000
+// eth1_data =
+// deposit_root = 0x1a4c3cce02935defd159e4e207890ae26a325bf03e205c9ee94ca040ecce008a
+// deposit_count = 21073
+// block_hash = 0xeeea1373d4aa9e099d7c9deddb694db9aeb4577755ef83f9b6345ce4357d9abf
+// GENESIS_FORK_VERSION = 0x00000000
+// genesis_fork_digest = 0xb5303f2a
+// pre_genesis_fork_digest = 0xf5a5fd42
+// pub const ONE_HUNDRED_PERCENT_BP = u64 = 10000;
+//
+// pub const GENESIS_TIME =

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,9 @@
+use beacon_api_client::Client;
+use url::Url;
+
+pub fn setup() -> Client {
+    let s = "http://127.0.0.1:5052/";
+    let url: Url = Url::parse(s).unwrap();
+    let client = Client::new(url);
+    client
+}

--- a/tests/integration_test_beacon_namespace.rs
+++ b/tests/integration_test_beacon_namespace.rs
@@ -1,0 +1,120 @@
+mod common;
+use crate::common::constants::*;
+use beacon_api_client::{CommitteeFilter, PublicKeyOrIndex, StateId, ValidatorStatus};
+/*
+- get_genesis_details
+- get_state_root
+- get_fork
+- get_finality_checkpoints
+- get_validators
+- get_validator
+- get_balance
+- get_committes
+- get_sync_committees
+- get_beacon_header_at_head
+- get_beacon_header_for_parent_root
+- get_beacon_header
+- post_signed_beacon_block
+- post_signed_blinded_beacon_block
+*/
+
+#[tokio::test]
+async fn test_get_genesis_details() {
+    let client = common::setup();
+    let genesis_details = client.get_genesis_details().await.unwrap();
+    assert_eq!(genesis_details.genesis_time, GENESIS_TIME);
+}
+
+#[tokio::test]
+async fn test_get_state_root() {
+    let client = common::setup();
+    let root = client.get_state_root(StateId::Genesis).await.unwrap();
+    assert_eq!(root.as_bytes(), GENESIS_STATE_ROOT);
+}
+
+#[tokio::test]
+async fn test_get_fork() {
+    let client = common::setup();
+    let data = client.get_fork(StateId::Genesis).await.unwrap();
+    assert_eq!(data.current_version.len(), 4);
+    let num = data
+        .current_version
+        .iter()
+        .fold(0_u32, |acc, value| (acc << 8) | *value as u32);
+    assert_eq!(num, GENESIS_FORK_VERSION);
+}
+// Seems pointless, it just returns zeros
+// #[tokio::test]
+// async fn test_get_finality_checkpoints() {
+//     let client = common::setup();
+//     let root = client.get_finality_checkpoints(StateId::Genesis).await.unwrap();
+//     dbg!(root);
+//     // assert_eq!(root, GENESIS_STATE_ROOT);
+//     assert_eq!(23, 32);
+// }
+
+#[tokio::test]
+async fn test_get_validators() {
+    let client = common::setup();
+    let index = 0;
+    let vec_validator_summary = client
+        .get_validators(
+            StateId::Genesis,
+            &[PublicKeyOrIndex::Index(index)],
+            &[ValidatorStatus::ActiveOngoing],
+        )
+        .await
+        .unwrap();
+    assert_eq!(vec_validator_summary[index].index, index);
+    assert_eq!(
+        vec_validator_summary[index]
+            .validator
+            .public_key
+            .to_string(),
+        VALIDATOR_0.to_string()
+    );
+}
+
+#[tokio::test]
+async fn test_get_validator() {
+    let client = common::setup();
+    let index = 0;
+    let validator_summary = client
+        .get_validator(StateId::Genesis, PublicKeyOrIndex::Index(index))
+        .await
+        .unwrap();
+    assert_eq!(validator_summary.index, index);
+    assert_eq!(
+        validator_summary.validator.public_key.to_string(),
+        VALIDATOR_0.to_string()
+    );
+}
+
+#[tokio::test]
+async fn test_get_balances() {
+    let client = common::setup();
+    let index = 0;
+    let vec_balances_summary = client
+        .get_balances(StateId::Genesis, &[PublicKeyOrIndex::Index(index)])
+        .await
+        .unwrap();
+    assert_eq!(vec_balances_summary[0].index, index);
+    assert_eq!(vec_balances_summary[0].balance, 32000000000);
+}
+
+#[tokio::test]
+async fn test_get_all_committees() {
+    let client = common::setup();
+    let result = client.get_all_committees(StateId::Genesis).await.unwrap();
+    assert_eq!(result.len(), 160);
+}
+
+#[tokio::test]
+async fn test_get_committees() {
+    let client = common::setup();
+    let result = client
+        .get_committees(StateId::Genesis, CommitteeFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(result.len(), 160);
+}

--- a/tests/integration_test_helpers.rs
+++ b/tests/integration_test_helpers.rs
@@ -1,6 +1,14 @@
 mod common;
 use http::StatusCode;
 
+/*
+Helpers to me include the following functions
+- get
+- http_get
+- post
+- http_post
+*/
+
 #[tokio::test]
 async fn test_http_get() {
     let clinet = common::setup();

--- a/tests/integration_test_helpers.rs
+++ b/tests/integration_test_helpers.rs
@@ -1,0 +1,19 @@
+mod common;
+use http::StatusCode;
+
+#[tokio::test]
+async fn test_http_get() {
+    let clinet = common::setup();
+    let path = "/eth/v1/builder/validators";
+    let response = clinet.http_get(path).await.unwrap();
+    assert_eq!(&response.url().as_str(), &"http://127.0.0.1:5052/eth/v1/builder/validators");
+    dbg!(&response.status());
+    assert_eq!(&response.status(), &StatusCode::METHOD_NOT_ALLOWED);
+}
+
+//#[tokio::test]
+//async fn test_get() {
+//    let client = common::setup();
+//    let path = "/eth/v1/builder/validatots";
+//    let response = client.
+//}


### PR DESCRIPTION
I read about integration tests as you suggested and found the tests/common pattern. 
I placed the setup for the integration tests in tests/common/mod.rs, all that file does right now Is returned a Client.
My plan is to add tests for helper function and each of the namespaces in their own files under the tests folder, for now I've only started with integration_test_helpers.rs.

@ralexstokes 