### PR TITLE
uses Box and dbg to tidy cli skeleton

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -46,12 +46,3 @@ pub struct ValidatorsArg {
     pub validator_id: PublicKeyOrIndex,
     pub status: ValidatorStatus,
 }
-
-// impl ValidatorArg {
-//     pub async fn execute(&self, client: &Client) {
-//         let id = &self.state_id;
-//         let validator_id = &self.validator_id;
-//         let out = client.get_validator(id.to_owned(), validator_id.to_owned()).await.unwrap();
-//         println!("{:?}", out);
-//     }
-// }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,4 +1,4 @@
-use crate::types::StateId;
+use crate::{types::StateId, PublicKeyOrIndex, ValidatorStatus};
 use clap::{Args, Parser, Subcommand};
 
 #[derive(Debug, Parser)]
@@ -21,6 +21,8 @@ pub enum Namespace {
 pub enum BeaconMethod {
     Genesis,
     Root(StateIdArg),
+    FinalityCheckpoints(StateIdArg),
+    Validators(ValidatorsArg),
 }
 
 #[derive(Args, Debug)]
@@ -37,3 +39,19 @@ pub struct StateIdArg {
     )]
     pub state_id: StateId,
 }
+
+#[derive(Args, Debug, Clone)]
+pub struct ValidatorsArg {
+    pub state_id: StateId,
+    pub validator_id: PublicKeyOrIndex,
+    pub status: ValidatorStatus,
+}
+
+// impl ValidatorArg {
+//     pub async fn execute(&self, client: &Client) {
+//         let id = &self.state_id;
+//         let validator_id = &self.validator_id;
+//         let out = client.get_validator(id.to_owned(), validator_id.to_owned()).await.unwrap();
+//         println!("{:?}", out);
+//     }
+// }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,5 @@
 mod config;
-use crate::{mainnet::Client};
+use crate::mainnet::Client;
 pub use config::CliConfig;
 use config::{BeaconMethod, Namespace::Beacon};
 use std::fmt;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,14 +2,12 @@ mod config;
 use crate::mainnet::Client;
 pub use config::CliConfig;
 use config::{BeaconMethod, Namespace::Beacon};
+use crate::Error;
+use std::fmt;
 
-pub async fn run_cli(client: &Client, args: &CliConfig) {
+pub async fn run_cli(client: &Client, args: &CliConfig) -> Box<dyn fmt::Debug>{
     match &args.namespace {
-        Beacon(BeaconMethod::Genesis) => {
-            println!("{:?}", &client.get_genesis_details().await.unwrap());
-        }
-        Beacon(BeaconMethod::Root(arg)) => {
-            println!("{}", &client.get_state_root(arg.state_id.clone()).await.unwrap())
-        }
+        Beacon(BeaconMethod::Genesis) => Box::new(client.get_genesis_details().await),
+        Beacon(BeaconMethod::Root(arg)) => Box::new(client.get_state_root(arg.state_id.clone()).await)
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,13 +1,14 @@
 mod config;
-use crate::mainnet::Client;
+use crate::{mainnet::Client, Error};
 pub use config::CliConfig;
 use config::{BeaconMethod, Namespace::Beacon};
-use crate::Error;
 use std::fmt;
 
-pub async fn run_cli(client: &Client, args: &CliConfig) -> Box<dyn fmt::Debug>{
+pub async fn run_cli(client: &Client, args: &CliConfig) -> Box<dyn fmt::Debug> {
     match &args.namespace {
         Beacon(BeaconMethod::Genesis) => Box::new(client.get_genesis_details().await),
-        Beacon(BeaconMethod::Root(arg)) => Box::new(client.get_state_root(arg.state_id.clone()).await)
+        Beacon(BeaconMethod::Root(arg)) => {
+            Box::new(client.get_state_root(arg.state_id.clone()).await)
+        }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,5 @@
 mod config;
-use crate::{mainnet::Client, Error};
+use crate::{mainnet::Client};
 pub use config::CliConfig;
 use config::{BeaconMethod, Namespace::Beacon};
 use std::fmt;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,11 +4,25 @@ pub use config::CliConfig;
 use config::{BeaconMethod, Namespace::Beacon};
 use std::fmt;
 
+use self::config::StateIdArg;
+
 pub async fn run_cli(client: &Client, args: &CliConfig) -> Box<dyn fmt::Debug> {
     match &args.namespace {
         Beacon(BeaconMethod::Genesis) => Box::new(client.get_genesis_details().await),
         Beacon(BeaconMethod::Root(arg)) => {
             Box::new(client.get_state_root(arg.state_id.clone()).await)
         }
+        Beacon(BeaconMethod::FinalityCheckpoints(arg)) => {
+            Box::new(client.get_finality_checkpoints(arg.state_id.clone()).await)
+        }
+        Beacon(BeaconMethod::Validators(arg)) => Box::new(
+            client
+                .get_validators(
+                    arg.state_id.to_owned(),
+                    &[arg.validator_id.to_owned()],
+                    &[arg.status],
+                )
+                .await,
+        ),
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,28 +1,32 @@
 mod config;
-use crate::mainnet::Client;
+use crate::{mainnet::Client, Error};
 pub use config::CliConfig;
 use config::{BeaconMethod, Namespace::Beacon};
 use std::fmt;
 
-use self::config::StateIdArg;
-
-pub async fn run_cli(client: &Client, args: &CliConfig) -> Box<dyn fmt::Debug> {
+pub async fn run_cli(client: &Client, args: &CliConfig) -> Result<Box<dyn fmt::Debug>, Error> {
     match &args.namespace {
-        Beacon(BeaconMethod::Genesis) => Box::new(client.get_genesis_details().await),
+        Beacon(BeaconMethod::Genesis) => {
+            let result = client.get_genesis_details().await?;
+            Ok(Box::new(result))
+        }
         Beacon(BeaconMethod::Root(arg)) => {
-            Box::new(client.get_state_root(arg.state_id.clone()).await)
+            let result = client.get_state_root(arg.state_id.clone()).await?;
+            Ok(Box::new(result))
         }
         Beacon(BeaconMethod::FinalityCheckpoints(arg)) => {
-            Box::new(client.get_finality_checkpoints(arg.state_id.clone()).await)
+            let result = client.get_finality_checkpoints(arg.state_id.clone()).await?;
+            Ok(Box::new(result))
         }
-        Beacon(BeaconMethod::Validators(arg)) => Box::new(
-            client
+        Beacon(BeaconMethod::Validators(arg)) => {
+            let result = client
                 .get_validators(
                     arg.state_id.to_owned(),
                     &[arg.validator_id.to_owned()],
                     &[arg.status],
                 )
-                .await,
-        ),
+                .await?;
+            Ok(Box::new(result))
+        }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,7 +11,7 @@ pub async fn run_cli(client: &Client, args: &CliConfig) -> Result<Box<dyn fmt::D
             Ok(Box::new(result))
         }
         Beacon(BeaconMethod::Root(arg)) => {
-            let result = client.get_state_root(arg.state_id.clone()).await?;
+            let result = client.get_state_root(&arg.state_id).await?;
             Ok(Box::new(result))
         }
         Beacon(BeaconMethod::FinalityCheckpoints(arg)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,5 +7,5 @@ async fn main() {
     let args = CliConfig::parse();
     let url = Url::parse(&args.endpoint).unwrap();
     let client = Client::new(url);
-    run_cli(&client, &args).await;
+    dbg!(run_cli(&client, &args).await);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use beacon_api_client::{mainnet::Client, run_cli, CliConfig, Error};
+use beacon_api_client::{mainnet::Client, run_cli, CliConfig};
 use clap::Parser;
 use url::Url;
 
@@ -7,6 +7,6 @@ async fn main() -> Result<(), beacon_api_client::Error> {
     let args = CliConfig::parse();
     let url = Url::parse(&args.endpoint).unwrap();
     let client = Client::new(url);
-    dbg!(run_cli(&client, &args).await)?;
+    dbg!(run_cli(&client, &args).await?);
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
-use beacon_api_client::{mainnet::Client, run_cli, CliConfig};
+use beacon_api_client::{mainnet::Client, run_cli, CliConfig, Error};
 use clap::Parser;
 use url::Url;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), beacon_api_client::Error> {
     let args = CliConfig::parse();
     let url = Url::parse(&args.endpoint).unwrap();
     let client = Client::new(url);
-    dbg!(run_cli(&client, &args).await);
+    dbg!(run_cli(&client, &args).await)?;
+    Ok(())
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,7 +32,7 @@ pub struct DepositContract {
     pub address: ExecutionAddress,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct GenesisDetails {
     #[serde(with = "crate::serde::as_string")]
     pub genesis_time: u64,

--- a/src/types.rs
+++ b/src/types.rs
@@ -124,7 +124,7 @@ enum ExecutionStatus {
     Optimistic,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Debug, Deserialize)]
 pub struct FinalityCheckpoints {
     pub previous_justified: Checkpoint,
     pub current_justified: Checkpoint,
@@ -170,7 +170,29 @@ impl fmt::Display for ValidatorStatus {
     }
 }
 
-#[derive(Debug)]
+impl FromStr for ValidatorStatus {
+    type Err = &'static str;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pending_initialized" => Ok(ValidatorStatus::PendingInitialized),
+            "pending_queued" => Ok(ValidatorStatus::PendingQueued),
+            "active_ongoing" => Ok(ValidatorStatus::ActiveOngoing),
+            "active_exiting" => Ok(ValidatorStatus::ActiveExiting),
+            "active_slashed" => Ok(ValidatorStatus::ActiveSlashed),
+            "exited_unslashed" => Ok(ValidatorStatus::ExitedUnslashed),
+            "exited_slashed" => Ok(ValidatorStatus::ExitedSlashed),
+            "withdrawal_possible" => Ok(ValidatorStatus::WithdrawalPossible),
+            "withdrawal_done" => Ok(ValidatorStatus::WithdrawalDone),
+            "active" => Ok(ValidatorStatus::Active),
+            "pending" => Ok(ValidatorStatus::Pending),
+            "exited" => Ok(ValidatorStatus::Exited),
+            "withdrawal" => Ok(ValidatorStatus::Withdrawal),
+            _ => Err("invalid input to validator status"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub enum PublicKeyOrIndex {
     PublicKey(BlsPublicKey),
     Index(ValidatorIndex),
@@ -195,6 +217,17 @@ impl From<ValidatorIndex> for PublicKeyOrIndex {
 impl From<BlsPublicKey> for PublicKeyOrIndex {
     fn from(public_key: BlsPublicKey) -> Self {
         Self::PublicKey(public_key)
+    }
+}
+
+impl From<String> for PublicKeyOrIndex {
+    fn from(s: String) -> Self {
+        match try_bytes_from_hex_str(&s) {
+            Ok(..) => {
+                Self::PublicKey(try_bytes_from_hex_str(&s).unwrap().as_slice().try_into().unwrap())
+            }
+            _ => Self::Index(s.parse::<usize>().unwrap()),
+        }
     }
 }
 


### PR DESCRIPTION
Improves the cli skeleton by removing the `println!` and `unwrap()` pattern and instead returning `Box<dyn fmt::Debug>` from `run_cli`.

Contributes to https://github.com/ralexstokes/ethereum-consensus/issues/240
