### PR TITLE
feat: impl beacon APIs 2.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ serde_json = "1.0.81"
 itertools = "0.10.3"
 clap = {version = "4.3.11", features = ["derive"], optional = true }
 thiserror = "1.0.30"
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "e380108" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "27ca9b6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ serde_json = "1.0.81"
 itertools = "0.10.3"
 clap = {version = "4.3.11", features = ["derive"], optional = true }
 thiserror = "1.0.30"
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "27ca9b6" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "56418ea" }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,6 @@
 use crate::ApiError;
 use ethereum_consensus::{
     altair::MetaData,
-    capella::Withdrawal,
     networking::{Enr, Multiaddr, PeerId},
     phase0::{Checkpoint, SignedBeaconBlockHeader, Validator},
     primitives::{
@@ -448,13 +447,6 @@ pub struct BeaconProposerRegistration {
     #[serde(with = "crate::serde::as_string")]
     pub validator_index: ValidatorIndex,
     pub fee_recipient: ExecutionAddress,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ExpectedWithdrawals {
-    pub execution_optimistic: bool,
-    pub finalized: bool,
-    pub data: Vec<Withdrawal>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -251,6 +251,24 @@ pub struct BeaconHeaderSummary {
     pub signed_header: SignedBeaconBlockHeader,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub enum BroadcastValidation {
+    Gossip,
+    Consensus,
+    ConsensusAndEquivocation,
+}
+
+impl fmt::Display for BroadcastValidation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let printable = match self {
+            Self::Gossip => "gossip",
+            Self::Consensus => "consensus",
+            Self::ConsensusAndEquivocation => "consensus_and_equivocation",
+        };
+        write!(f, "{printable}")
+    }
+}
+
 pub enum EventTopic {
     Head,
     Block,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,11 +1,12 @@
 use crate::ApiError;
 use ethereum_consensus::{
     altair::MetaData,
+    capella::Withdrawal,
     networking::{Enr, Multiaddr, PeerId},
     phase0::{Checkpoint, SignedBeaconBlockHeader, Validator},
     primitives::{
-        BlsPublicKey, ChainId, CommitteeIndex, Coordinate, Epoch, ExecutionAddress, Gwei, Root,
-        Slot, ValidatorIndex, Version,
+        BlsPublicKey, ChainId, CommitteeIndex, Coordinate, Epoch, ExecutionAddress, Gwei, Hash32,
+        Root, Slot, ValidatorIndex, Version,
     },
     serde::try_bytes_from_hex_str,
 };
@@ -30,6 +31,17 @@ pub struct DepositContract {
     #[serde(with = "crate::serde::as_string")]
     pub chain_id: ChainId,
     pub address: ExecutionAddress,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DepositSnapshot {
+    pub finalized: Vec<Hash32>,
+    pub deposit_root: Hash32,
+    #[serde(with = "crate::serde::as_string")]
+    pub deposit_count: u64,
+    pub execution_block_hash: Hash32,
+    #[serde(with = "crate::serde::as_string")]
+    pub execution_block_height: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -436,6 +448,20 @@ pub struct BeaconProposerRegistration {
     #[serde(with = "crate::serde::as_string")]
     pub validator_index: ValidatorIndex,
     pub fee_recipient: ExecutionAddress,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExpectedWithdrawals {
+    pub execution_optimistic: bool,
+    pub finalized: bool,
+    pub data: Vec<Withdrawal>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ValidatorLiveness {
+    #[serde(with = "crate::serde::as_string")]
+    index: ValidatorIndex,
+    is_live: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
resolves #70 

the following APIs are omitted for the following reasons:

* marked experimental:
  * [`/eth/v1/beacon/rewards/sync_committee/{block_id}`](https://ethereum.github.io/beacon-APIs/#/Beacon/getSyncCommitteeRewards)
  * [`/eth/v1/beacon/rewards/blocks/{block_id}`](https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockRewards)
  * [`/eth/v1/beacon/rewards/attestations/{epoch}`](https://ethereum.github.io/beacon-APIs/#/Beacon/getAttestationsRewards)
* unsure: [`/eth/v1/debug/fork_choice`](https://ethereum.github.io/beacon-APIs/#/Debug/getDebugForkChoice)
* marked for DVT middleware:
  * [`/eth/v1/validator/beacon_committee_selections`](https://ethereum.github.io/beacon-APIs/#/Validator/submitBeaconCommitteeSelections)
  * [`/eth/v1/validator/sync_committee_selections`](https://ethereum.github.io/beacon-APIs/#/Validator/submitSyncCommitteeSelections)

fixes:

* [`/eth/v1/validator/blinded_blocks/{slot}`](https://ethereum.github.io/beacon-APIs/#/Validator/produceBlindedBlock) from `v2` to `v1`